### PR TITLE
support for Deserializing ISO8601 formatted string to DateTime

### DIFF
--- a/src/SimpleJson.Tests/PocoDeserializerTests/DateTimeDeserializeTests.cs
+++ b/src/SimpleJson.Tests/PocoDeserializerTests/DateTimeDeserializeTests.cs
@@ -1,4 +1,22 @@
-﻿
+﻿//-----------------------------------------------------------------------
+// <copyright file="<file>.cs" company="The Outercurve Foundation">
+//    Copyright (c) 2011, The Outercurve Foundation.
+//
+//    Licensed under the MIT License (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//      http://www.opensource.org/licenses/mit-license.php
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// </copyright>
+// <author>Nathan Totten (ntotten.com), Jim Zimmerman (jimzimmerman.com) and Prabir Shrestha (prabir.me)</author>
+// <website>https://github.com/facebook-csharp-sdk/simple-json</website>
+//-----------------------------------------------------------------------
+
 namespace SimpleJson.Tests.PocoDeserializerTests
 {
 #if NUNIT

--- a/src/SimpleJson.Tests/PocoDeserializerTests/DateTimeDeserializeTests.cs
+++ b/src/SimpleJson.Tests/PocoDeserializerTests/DateTimeDeserializeTests.cs
@@ -1,7 +1,9 @@
 ﻿
-namespace SimpleJson.Tests.PocoJsonSerializerTests
+namespace SimpleJson.Tests.PocoDeserializerTests
 {
 #if NUNIT
+    using System;
+    using System.Globalization;
     using TestClass = NUnit.Framework.TestFixtureAttribute;
     using TestMethod = NUnit.Framework.TestAttribute;
     using TestCleanup = NUnit.Framework.TearDownAttribute;
@@ -9,25 +11,26 @@ namespace SimpleJson.Tests.PocoJsonSerializerTests
     using ClassCleanup = NUnit.Framework.TestFixtureTearDownAttribute;
     using ClassInitialize = NUnit.Framework.TestFixtureSetUpAttribute;
     using NUnit.Framework;
-    using System;
 #else
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 #endif
 
     [TestClass]
-    public class DateTimeSerializeTests
+    public class DateTimeDeserializeTests
     {
         [TestMethod]
-        public void SerializeDateTime()
+        public void Test()
         {
-            var obj = new SerializeDateTimeTypeClass
-                          {
-                              Value = new DateTime(2004, 1, 20, 5, 3, 6, DateTimeKind.Utc)
-                          };
+            var json = "{\"Value\":\"2004-01-20T05:03:06Z\"}";
 
-            var json = SimpleJson.SerializeObject(obj);
-
-            Assert.AreEqual("{\"Value\":\"2004-01-20T05:03:06Z\"}", json);
+            var result = SimpleJson.DeserializeObject<SerializeDateTimeTypeClass>(json).Value;
+            Assert.AreEqual(2004, result.Year);
+            Assert.AreEqual(1, result.Month);
+            Assert.AreEqual(20, result.Day);
+            Assert.AreEqual(5, result.Hour);
+            Assert.AreEqual(3, result.Minute);
+            Assert.AreEqual(6, result.Second);
+            Assert.AreEqual(DateTimeKind.Utc, result.Kind);
         }
 
         public class SerializeDateTimeTypeClass

--- a/src/SimpleJson.Tests/PocoDeserializerTests/DateTimeDeserializeTests.cs
+++ b/src/SimpleJson.Tests/PocoDeserializerTests/DateTimeDeserializeTests.cs
@@ -21,7 +21,6 @@ namespace SimpleJson.Tests.PocoDeserializerTests
 {
 #if NUNIT
     using System;
-    using System.Globalization;
     using TestClass = NUnit.Framework.TestFixtureAttribute;
     using TestMethod = NUnit.Framework.TestAttribute;
     using TestCleanup = NUnit.Framework.TearDownAttribute;
@@ -48,6 +47,23 @@ namespace SimpleJson.Tests.PocoDeserializerTests
             Assert.AreEqual(5, result.Hour);
             Assert.AreEqual(3, result.Minute);
             Assert.AreEqual(6, result.Second);
+            Assert.AreEqual(0, result.Millisecond);
+            Assert.AreEqual(DateTimeKind.Utc, result.Kind);
+        }
+
+        [TestMethod]
+        public void TestWithMilliSecond()
+        {
+            var json = "{\"Value\":\"2004-01-20T05:03:06.012Z\"}";
+
+            var result = SimpleJson.DeserializeObject<SerializeDateTimeTypeClass>(json).Value;
+            Assert.AreEqual(2004, result.Year);
+            Assert.AreEqual(1, result.Month);
+            Assert.AreEqual(20, result.Day);
+            Assert.AreEqual(5, result.Hour);
+            Assert.AreEqual(3, result.Minute);
+            Assert.AreEqual(6, result.Second);
+            Assert.AreEqual(12, result.Millisecond);
             Assert.AreEqual(DateTimeKind.Utc, result.Kind);
         }
 

--- a/src/SimpleJson.Tests/PocoJsonSerializerTests/DateTimeSerializeTests.cs
+++ b/src/SimpleJson.Tests/PocoJsonSerializerTests/DateTimeSerializeTests.cs
@@ -36,12 +36,25 @@ namespace SimpleJson.Tests.PocoJsonSerializerTests
     public class DateTimeSerializeTests
     {
         [TestMethod]
-        public void SerializeDateTime()
+        public void SerializeDateTimeThatHasMilliSecondAsNonZero()
         {
             var obj = new SerializeDateTimeTypeClass
                           {
-                              Value = new DateTime(2004, 1, 20, 5, 3, 6, DateTimeKind.Utc)
+                              Value = new DateTime(2004, 1, 20, 5, 3, 6, 12, DateTimeKind.Utc)
                           };
+
+            var json = SimpleJson.SerializeObject(obj);
+
+            Assert.AreEqual("{\"Value\":\"2004-01-20T05:03:06.012Z\"}", json);
+        }
+
+        [TestMethod]
+        public void SerializeDateTimeThatHasMilliSecondAsZero()
+        {
+            var obj = new SerializeDateTimeTypeClass
+            {
+                Value = new DateTime(2004, 1, 20, 5, 3, 6, 0, DateTimeKind.Utc)
+            };
 
             var json = SimpleJson.SerializeObject(obj);
 

--- a/src/SimpleJson.Tests/PocoJsonSerializerTests/DateTimeSerializeTests.cs
+++ b/src/SimpleJson.Tests/PocoJsonSerializerTests/DateTimeSerializeTests.cs
@@ -1,4 +1,22 @@
-﻿
+﻿//-----------------------------------------------------------------------
+// <copyright file="<file>.cs" company="The Outercurve Foundation">
+//    Copyright (c) 2011, The Outercurve Foundation.
+//
+//    Licensed under the MIT License (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//      http://www.opensource.org/licenses/mit-license.php
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// </copyright>
+// <author>Nathan Totten (ntotten.com), Jim Zimmerman (jimzimmerman.com) and Prabir Shrestha (prabir.me)</author>
+// <website>https://github.com/facebook-csharp-sdk/simple-json</website>
+//-----------------------------------------------------------------------
+
 namespace SimpleJson.Tests.PocoJsonSerializerTests
 {
 #if NUNIT

--- a/src/SimpleJson.Tests/PocoJsonSerializerTests/DateTimeSerializeTests.cs
+++ b/src/SimpleJson.Tests/PocoJsonSerializerTests/DateTimeSerializeTests.cs
@@ -1,0 +1,38 @@
+﻿
+namespace SimpleJson.Tests.PocoJsonSerializerTests
+{
+#if NUNIT
+    using TestClass = NUnit.Framework.TestFixtureAttribute;
+    using TestMethod = NUnit.Framework.TestAttribute;
+    using TestCleanup = NUnit.Framework.TearDownAttribute;
+    using TestInitialize = NUnit.Framework.SetUpAttribute;
+    using ClassCleanup = NUnit.Framework.TestFixtureTearDownAttribute;
+    using ClassInitialize = NUnit.Framework.TestFixtureSetUpAttribute;
+    using NUnit.Framework;
+    using System;
+#else
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+#endif
+
+    [TestClass]
+    public class DateTimeSerializeTests
+    {
+        [TestMethod]
+        public void SerializeDateTime()
+        {
+            var obj = new SerializeDateTimeTypeClass
+                          {
+                              Value = new DateTime(2004, 1, 20, 5, 3, 6, DateTimeKind.Utc)
+                          };
+
+            var json = SimpleJson.SerializeObject(obj);
+
+            Assert.AreEqual("{\"Value\":\"2004-01-20T05:03:06.0000000Z\"}", json);
+        }
+
+        public class SerializeDateTimeTypeClass
+        {
+            public DateTime Value { get; set; }
+        }
+    }
+}

--- a/src/SimpleJson.Tests/PocoJsonSerializerTests/NullableSerializeTests.cs
+++ b/src/SimpleJson.Tests/PocoJsonSerializerTests/NullableSerializeTests.cs
@@ -1,4 +1,23 @@
-﻿namespace SimpleJsonTests.PocoJsonSerializerTests
+﻿//-----------------------------------------------------------------------
+// <copyright file="<file>.cs" company="The Outercurve Foundation">
+//    Copyright (c) 2011, The Outercurve Foundation.
+//
+//    Licensed under the MIT License (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//      http://www.opensource.org/licenses/mit-license.php
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// </copyright>
+// <author>Nathan Totten (ntotten.com), Jim Zimmerman (jimzimmerman.com) and Prabir Shrestha (prabir.me)</author>
+// <website>https://github.com/facebook-csharp-sdk/simple-json</website>
+//-----------------------------------------------------------------------
+
+namespace SimpleJsonTests.PocoJsonSerializerTests
 {
 #if NUNIT
     using TestClass = NUnit.Framework.TestFixtureAttribute;

--- a/src/SimpleJson.Tests/SerializeObject.UnknownNonPrimitive.Tests.cs
+++ b/src/SimpleJson.Tests/SerializeObject.UnknownNonPrimitive.Tests.cs
@@ -100,11 +100,24 @@ namespace SimpleJsonTests
         }
 
         [TestMethod]
-        public void CanSerializeWithDates()
+        public void CanSerializeWithDatesThatHasMilliSecondAsNonZero()
         {
             var instance = new
             {
                 now = new DateTime(2004, 1, 20, 5, 3, 6, 12, DateTimeKind.Utc)
+            };
+
+            var json = SimpleJson.SerializeObject(instance);
+            Assert.IsNotNull(json);
+            Assert.AreEqual("{\"now\":\"2004-01-20T05:03:06.012Z\"}", json);
+        }
+
+        [TestMethod]
+        public void CanSerializeWithDatesThatHasMilliSecondAsZero()
+        {
+            var instance = new
+            {
+                now = new DateTime(2004, 1, 20, 5, 3, 6, 0, DateTimeKind.Utc)
             };
 
             var json = SimpleJson.SerializeObject(instance);

--- a/src/SimpleJson.Tests/SerializeObject.UnknownNonPrimitive.Tests.cs
+++ b/src/SimpleJson.Tests/SerializeObject.UnknownNonPrimitive.Tests.cs
@@ -104,11 +104,12 @@ namespace SimpleJsonTests
         {
             var instance = new
             {
-                now = DateTime.UtcNow
+                now = new DateTime(2004, 1, 20, 5, 3, 6, DateTimeKind.Utc)
             };
 
             var json = SimpleJson.SerializeObject(instance);
             Assert.IsNotNull(json);
+            Assert.AreEqual("{\"now\":\"2004-01-20T05:03:06.0000000Z\"}", json);
         }
 
         [TestMethod]

--- a/src/SimpleJson.Tests/SerializeObject.UnknownNonPrimitive.Tests.cs
+++ b/src/SimpleJson.Tests/SerializeObject.UnknownNonPrimitive.Tests.cs
@@ -104,12 +104,12 @@ namespace SimpleJsonTests
         {
             var instance = new
             {
-                now = new DateTime(2004, 1, 20, 5, 3, 6, DateTimeKind.Utc)
+                now = new DateTime(2004, 1, 20, 5, 3, 6, 12, DateTimeKind.Utc)
             };
 
             var json = SimpleJson.SerializeObject(instance);
             Assert.IsNotNull(json);
-            Assert.AreEqual("{\"now\":\"2004-01-20T05:03:06.0000000Z\"}", json);
+            Assert.AreEqual("{\"now\":\"2004-01-20T05:03:06Z\"}", json);
         }
 
         [TestMethod]

--- a/src/SimpleJson.Tests/SimpleJson.Tests.csproj
+++ b/src/SimpleJson.Tests/SimpleJson.Tests.csproj
@@ -72,6 +72,7 @@
     <Compile Include="PocoDeserializerTests\ArrayTests.cs" />
     <Compile Include="PocoDeserializerTests\DictionaryDeserializeTests.cs" />
     <Compile Include="PocoDeserializerTests\ListOfPocoDeserializeTests.cs" />
+    <Compile Include="PocoJsonSerializerTests\DateTimeSerializeTests.cs" />
     <Compile Include="PocoJsonSerializerTests\NullableSerializeTests.cs" />
     <Compile Include="PocoJsonSerializerTests\PrivateFieldsDeserializeTests.cs" />
     <Compile Include="PocoJsonSerializerTests\PrivateFieldsSerializeTests.cs" />

--- a/src/SimpleJson.Tests/SimpleJson.Tests.csproj
+++ b/src/SimpleJson.Tests/SimpleJson.Tests.csproj
@@ -70,6 +70,7 @@
     <Compile Include="JsonDecodeTypeTests.cs" />
     <Compile Include="JsonDataContractSerializeObjectTests.cs" />
     <Compile Include="PocoDeserializerTests\ArrayTests.cs" />
+    <Compile Include="PocoDeserializerTests\DateTimeDeserializeTests.cs" />
     <Compile Include="PocoDeserializerTests\DictionaryDeserializeTests.cs" />
     <Compile Include="PocoDeserializerTests\ListOfPocoDeserializeTests.cs" />
     <Compile Include="PocoJsonSerializerTests\DateTimeSerializeTests.cs" />

--- a/src/SimpleJson/SimpleJson.cs
+++ b/src/SimpleJson/SimpleJson.cs
@@ -1266,6 +1266,12 @@ namespace SimpleJson
     {
         internal CacheResolver CacheResolver;
 
+        private static readonly string[] Iso8601Format = new string[]
+                                                             {
+                                                                 @"yyyy-MM-dd\THH:mm:ss\Z",
+                                                                 @"yyyy-MM-dd\THH:mm:ssK"
+                                                             };
+
         public PocoJsonSerializerStrategy()
         {
             CacheResolver = new CacheResolver(BuildMap);
@@ -1369,7 +1375,16 @@ namespace SimpleJson
                             if (jsonObject.ContainsKey(jsonKey))
                             {
                                 object jsonValue = DeserializeObject(jsonObject[jsonKey], v.Type);
-                                v.Setter(obj, jsonValue);
+                                if (v.Type == typeof(DateTime))
+                                {
+                                    string jsonValueStr = jsonValue as string;
+                                    if (!string.IsNullOrEmpty(jsonValueStr))
+                                        v.Setter(obj, DateTime.ParseExact(jsonValueStr, Iso8601Format, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal));
+                                }
+                                else
+                                {
+                                    v.Setter(obj, jsonValue);
+                                }
                             }
                         }
                     }
@@ -1421,7 +1436,7 @@ namespace SimpleJson
         {
             bool returnValue = true;
             if (input is DateTime)
-                output = ((DateTime)input).ToString("o");
+                output = ((DateTime)input).ToUniversalTime().ToString(Iso8601Format[0], CultureInfo.InvariantCulture);
             else if (input is Guid)
                 output = ((Guid)input).ToString("D");
             else if (input is Uri)

--- a/src/SimpleJson/SimpleJson.cs
+++ b/src/SimpleJson/SimpleJson.cs
@@ -1268,6 +1268,7 @@ namespace SimpleJson
 
         private static readonly string[] Iso8601Format = new string[]
                                                              {
+                                                                 @"yyyy-MM-dd\THH:mm:ss.FFFFFFF\Z",
                                                                  @"yyyy-MM-dd\THH:mm:ss\Z",
                                                                  @"yyyy-MM-dd\THH:mm:ssK"
                                                              };


### PR DESCRIPTION
pull request for #13

DateTime string format is `2004-01-20T05:03:06.012Z` if it has milliseconds, it if it does not have milliseconds it is  `2004-01-20T05:03:06Z`
