### PR TITLE
Add support for DateTimeOffset

### DIFF
--- a/src/SimpleJson.Tests/PocoDeserializerTests/DateTimeDeserializeTests.cs
+++ b/src/SimpleJson.Tests/PocoDeserializerTests/DateTimeDeserializeTests.cs
@@ -92,5 +92,31 @@ namespace SimpleJson.Tests.PocoDeserializerTests
         {
             public DateTime Value { get; set; }
         }
+
+     
+    }
+
+    public class DateOffsetTimeDeserializeTests
+    {
+        [TestMethod]
+        public void TestWithMilliSecond()
+        {
+            var json = "{\"Value\":\"2004-01-20T05:03:06.012Z\"}";
+
+            var result = SimpleJson.DeserializeObject<SerializeDateTimeOffsetTypeClass>(json).Value;
+            Assert.AreEqual(2004, result.Year);
+            Assert.AreEqual(1, result.Month);
+            Assert.AreEqual(20, result.Day);
+            Assert.AreEqual(5, result.Hour);
+            Assert.AreEqual(3, result.Minute);
+            Assert.AreEqual(6, result.Second);
+            Assert.AreEqual(12, result.Millisecond);
+            Assert.AreEqual(TimeSpan.Zero, result.Offset);
+        }
+
+        public class SerializeDateTimeOffsetTypeClass
+        {
+            public DateTimeOffset Value { get; set; }
+        }
     }
 }

--- a/src/SimpleJson.Tests/PocoDeserializerTests/NullableTypeDeserializeTests.cs
+++ b/src/SimpleJson.Tests/PocoDeserializerTests/NullableTypeDeserializeTests.cs
@@ -88,6 +88,33 @@ namespace SimpleJson.Tests.PocoDeserializerTests
         }
 
         [TestMethod]
+        public void DateTimeOffsetAsNull()
+        {
+            var json = "null";
+
+            var result = SimpleJson.DeserializeObject<DateTimeOffset?>(json);
+
+            Assert.IsFalse(result.HasValue);
+        }
+
+        [TestMethod]
+        public void DateTimeOffsetWithValue()
+        {
+            var json = "\"2004-01-20T05:03:06Z\"";
+
+            var result = SimpleJson.DeserializeObject<DateTimeOffset?>(json).Value;
+
+            Assert.AreEqual(2004, result.Year);
+            Assert.AreEqual(1, result.Month);
+            Assert.AreEqual(20, result.Day);
+            Assert.AreEqual(5, result.Hour);
+            Assert.AreEqual(3, result.Minute);
+            Assert.AreEqual(6, result.Second);
+            Assert.AreEqual(0, result.Millisecond);
+            Assert.AreEqual(TimeSpan.Zero, result.Offset);
+        }
+
+        [TestMethod]
         public void NullableTypeClassNullTest()
         {
             var json = "{\"Value\":null}";

--- a/src/SimpleJson.Tests/PocoJsonSerializerTests/DateTimeSerializeTests.cs
+++ b/src/SimpleJson.Tests/PocoJsonSerializerTests/DateTimeSerializeTests.cs
@@ -71,4 +71,26 @@ namespace SimpleJson.Tests.PocoJsonSerializerTests
             public DateTime Value { get; set; }
         }
     }
+
+    [TestClass]
+    public class DateTimeOffsetSerializeTests
+    {
+        [TestMethod]
+        public void SerializeDateTimeOffsetThatHasMilliSecondAsNonZero()
+        {
+            var obj = new SerializeDateTimeOffsetTypeClass
+                          {
+                              Value = new DateTimeOffset(2004, 1, 20, 5, 3, 6, 12, TimeSpan.Zero)
+                          };
+
+            var json = SimpleJson.SerializeObject(obj);
+
+            Assert.AreEqual("{\"Value\":\"2004-01-20T05:03:06.012Z\"}", json);
+        }
+
+        public class SerializeDateTimeOffsetTypeClass
+        {
+            public DateTimeOffset Value { get; set; }
+        }
+    }
 }

--- a/src/SimpleJson.Tests/PocoJsonSerializerTests/NullableSerializeTests.cs
+++ b/src/SimpleJson.Tests/PocoJsonSerializerTests/NullableSerializeTests.cs
@@ -61,6 +61,26 @@ namespace SimpleJsonTests.PocoJsonSerializerTests
         }
 
         [TestMethod]
+        public void TestNullDateTimeOffset()
+        {
+            DateTimeOffset? obj = null;
+
+            var json = SimpleJson.SimpleJson.SerializeObject(obj);
+
+            Assert.AreEqual("null", json);
+        }
+
+        [TestMethod]
+        public void TestDateTimeOffsetWithValue()
+        {
+            DateTimeOffset? obj = new DateTimeOffset(2004, 1, 20, 5, 3, 6, 12, TimeSpan.Zero);
+
+            var json = SimpleJson.SimpleJson.SerializeObject(obj);
+
+            Assert.AreEqual("\"2004-01-20T05:03:06.012Z\"", json);
+        }
+
+        [TestMethod]
         public void SerializeNullableTypeThatIsNotNull()
         {
             var obj = new NullableTypeClass();

--- a/src/SimpleJson/SimpleJson.cs
+++ b/src/SimpleJson/SimpleJson.cs
@@ -1265,6 +1265,8 @@ namespace SimpleJson
                 {
                     if (type == typeof(DateTime) || (ReflectionUtils.IsNullableType(type) && Nullable.GetUnderlyingType(type) == typeof(DateTime)))
                         obj = DateTime.ParseExact(str, Iso8601Format, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+                    else if (type == typeof(DateTimeOffset) || (ReflectionUtils.IsNullableType(type) && Nullable.GetUnderlyingType(type) == typeof(DateTimeOffset)))
+                        obj = DateTimeOffset.ParseExact(str, Iso8601Format, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
                     else if (type == typeof(Guid) || (ReflectionUtils.IsNullableType(type) && Nullable.GetUnderlyingType(type) == typeof(Guid)))
                         obj = new Guid(str);
                     else

--- a/src/SimpleJson/SimpleJson.cs
+++ b/src/SimpleJson/SimpleJson.cs
@@ -1383,6 +1383,8 @@ namespace SimpleJson
             bool returnValue = true;
             if (input is DateTime)
                 output = ((DateTime)input).ToUniversalTime().ToString(Iso8601Format[0], CultureInfo.InvariantCulture);
+            else if (input is DateTimeOffset)
+                output = ((DateTimeOffset)input).ToUniversalTime().ToString(Iso8601Format[0], CultureInfo.InvariantCulture);
             else if (input is Guid)
                 output = ((Guid)input).ToString("D");
             else if (input is Uri)


### PR DESCRIPTION
Adding support for DateTimeOffset. 

Also note that this wiki page: https://github.com/facebook-csharp-sdk/simple-json/wiki/Date-and-Time-Formats seems to be out of date. simple-json does support `DateTime`. At least the Poco serialization strategy does. It assumes ISO8601 (good choice!).

You might want to add a virtual method that allows a strategy to choose a different date format later. :)
