### PR TITLE
Adds capability to deserialise \Date("milisecs")\

### DIFF
--- a/src/SimpleJson.Tests/PocoDeserializerTests/DateTimeDeserializeTests.cs
+++ b/src/SimpleJson.Tests/PocoDeserializerTests/DateTimeDeserializeTests.cs
@@ -59,7 +59,7 @@ namespace SimpleJson.Tests.PocoDeserializerTests
         [TestMethod]
         public void MsJsonDateTimeNotation()
         {
-            var json = @"""/Date(1074574986000)/"""; //@"[\\/]+Date\((?<ticks>\d+)(?<direction>[-+]?)(?<offset>\d*)[\)\\/]+"
+            var json = @"""/Date(1074574986000)/""";
 
             var result = SimpleJson.DeserializeObject<DateTime>(json);
             Assert.AreEqual(2004, result.Year);
@@ -71,6 +71,23 @@ namespace SimpleJson.Tests.PocoDeserializerTests
             Assert.AreEqual(0, result.Millisecond);
             Assert.AreEqual(DateTimeKind.Utc, result.Kind);
         }
+
+        [TestMethod]
+        public void MsJsonDateTimeNotationWithOffset()
+        {
+            var json = @"""/Date(1074578586000+0100)/""";
+
+            var result = SimpleJson.DeserializeObject<DateTime>(json);
+            Assert.AreEqual(2004, result.Year);
+            Assert.AreEqual(1, result.Month);
+            Assert.AreEqual(20, result.Day);
+            Assert.AreEqual(5, result.Hour);
+            Assert.AreEqual(3, result.Minute);
+            Assert.AreEqual(6, result.Second);
+            Assert.AreEqual(0, result.Millisecond);
+            Assert.AreEqual(DateTimeKind.Utc, result.Kind);
+        }
+
 
 
         [TestMethod]

--- a/src/SimpleJson.Tests/PocoDeserializerTests/DateTimeDeserializeTests.cs
+++ b/src/SimpleJson.Tests/PocoDeserializerTests/DateTimeDeserializeTests.cs
@@ -57,6 +57,23 @@ namespace SimpleJson.Tests.PocoDeserializerTests
         }
 
         [TestMethod]
+        public void MsJsonDateTimeNotation()
+        {
+            var json = @"""/Date(1074574986000)/"""; //@"[\\/]+Date\((?<ticks>\d+)(?<direction>[-+]?)(?<offset>\d*)[\)\\/]+"
+
+            var result = SimpleJson.DeserializeObject<DateTime>(json);
+            Assert.AreEqual(2004, result.Year);
+            Assert.AreEqual(1, result.Month);
+            Assert.AreEqual(20, result.Day);
+            Assert.AreEqual(5, result.Hour);
+            Assert.AreEqual(3, result.Minute);
+            Assert.AreEqual(6, result.Second);
+            Assert.AreEqual(0, result.Millisecond);
+            Assert.AreEqual(DateTimeKind.Utc, result.Kind);
+        }
+
+
+        [TestMethod]
         public void TestWithoutMilisecond()
         {
             var json = "{\"Value\":\"2004-01-20T05:03:06Z\"}";

--- a/src/SimpleJson/SimpleJson.cs
+++ b/src/SimpleJson/SimpleJson.cs
@@ -1309,8 +1309,20 @@ namespace SimpleJson
                         Match match = DateSerializationRegex.Match(str);
 
                         if (match.Success)
-                            return new DateTime(Date1970Ticks + long.Parse(match.Groups["ticks"].Value) * 10000,
-                                                DateTimeKind.Utc);
+                        {
+                            long ticksSince1970 = long.Parse(match.Groups["ticks"].Value)*10000;
+                            int offset;
+                            if (int.TryParse(match.Groups["offset"].Value, out offset))
+                            {
+                                TimeSpan tsoffset = new TimeSpan(offset/100, offset%100, offset%10);
+                                if (match.Groups["direction"].Value == "+")
+                                    ticksSince1970 -= tsoffset.Ticks;
+                                else
+                                    ticksSince1970 += tsoffset.Ticks;
+                            }
+
+                            return new DateTime(Date1970Ticks + ticksSince1970, DateTimeKind.Utc);
+                        }
 
                         return DateTime.ParseExact(str, Iso8601Format, CultureInfo.InvariantCulture,
                                                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);

--- a/src/SimpleJson/SimpleJson.cs
+++ b/src/SimpleJson/SimpleJson.cs
@@ -1204,7 +1204,7 @@ namespace SimpleJson
  class PocoJsonSerializerStrategy : IJsonSerializerStrategy
     {
         private static readonly long Date1970Ticks = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc).Ticks;
-        private static readonly Regex DateSerializationRegex = new Regex(@"[\\/]+Date\((?<ticks>\d+)(?<direction>[-+]?)(?<offset>\d+)\)[\\/]+");
+        private static readonly Regex DateSerializationRegex = new Regex(@"[\\/]+Date\((?<ticks>\d+)(?<direction>[-+]?)(?<offset>\d*)[\)\\/]+");
 
         internal IDictionary<Type, ReflectionUtils.ConstructorDelegate> ConstructorCache;
         internal IDictionary<Type, IDictionary<string, ReflectionUtils.GetDelegate>> GetCache;
@@ -1310,7 +1310,7 @@ namespace SimpleJson
 
                         if (match.Success)
                             return new DateTime(Date1970Ticks + long.Parse(match.Groups["ticks"].Value) * 10000,
-                                                DateTimeKind.Utc).ToLocalTime();
+                                                DateTimeKind.Utc);
 
                         return DateTime.ParseExact(str, Iso8601Format, CultureInfo.InvariantCulture,
                                                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);


### PR DESCRIPTION
Not all versions support RegexOptions.Compiled. So I left it out.
