### PR TITLE
Serialize inherited list from root JSON array

### DIFF
--- a/src/SimpleJson.Tests/DeserializeGenericListTests.cs
+++ b/src/SimpleJson.Tests/DeserializeGenericListTests.cs
@@ -1,0 +1,100 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="<file>.cs" company="The Outercurve Foundation">
+//    Copyright (c) 2011, The Outercurve Foundation.
+//
+//    Licensed under the MIT License (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//      http://www.opensource.org/licenses/mit-license.php
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// </copyright>
+// <author>Nathan Totten (ntotten.com), Jim Zimmerman (jimzimmerman.com) and Prabir Shrestha (prabir.me)</author>
+// <website>https://github.com/facebook-csharp-sdk/simple-json</website>
+//-----------------------------------------------------------------------
+
+namespace SimpleJsonTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Runtime.Serialization;
+
+#if NUNIT
+    using TestClass = NUnit.Framework.TestFixtureAttribute;
+    using TestMethod = NUnit.Framework.TestAttribute;
+    using TestCleanup = NUnit.Framework.TearDownAttribute;
+    using TestInitialize = NUnit.Framework.SetUpAttribute;
+    using ClassCleanup = NUnit.Framework.TestFixtureTearDownAttribute;
+    using ClassInitialize = NUnit.Framework.TestFixtureSetUpAttribute;
+    using NUnit.Framework;
+#else
+#if NETFX_CORE
+    using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+#else
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+#endif
+#endif
+
+    using SimpleJson;
+
+    [TestClass]
+    public class DeserializeGenericListTests
+    {
+        private class NumberList : List<int>
+        {
+        }
+
+        private class ItemList : List<Item>
+        {
+        }
+
+        private class Item
+        {
+            public string SomeProperty { get; set; }
+        }
+
+        [TestMethod]
+        public void Can_Deserialize_Root_Json_Array_Of_Primitives_To_Inherited_List()
+        {
+            var json = "[0,1,2]";
+            var result = SimpleJson.DeserializeObject<NumberList>(json);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(3, result.Count);
+            for (int i = 0; i < 3; i++)
+            {
+                Assert.AreEqual(i, result[i]);
+            }
+        }
+
+        [TestMethod]
+        public void Can_Deserialize_Root_Json_Array_Of_Primitives_To_Generic_List()
+        {
+            var json = "[0,1,2]";
+            var result = SimpleJson.DeserializeObject<List<int>>(json);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(3, result.Count);
+            for (int i = 0; i < 3; i++)
+            {
+                Assert.AreEqual(i, result[i]);
+            }
+        }
+
+        [TestMethod]
+        public void Can_Deserialize_Root_Json_Array_To_Inherited_List()
+        {
+            var json = @"[{""SomeProperty"":""bar0""},{""SomeProperty"":""bar1""}]";
+            var result = SimpleJson.DeserializeObject<ItemList>(json);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual("bar0", result[0].SomeProperty);
+            Assert.AreEqual("bar1", result[1].SomeProperty);
+        }
+    }
+}

--- a/src/SimpleJson.Tests/SimpleJson.Tests.csproj
+++ b/src/SimpleJson.Tests/SimpleJson.Tests.csproj
@@ -52,6 +52,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DeserializeGenericListTests.cs" />
     <Compile Include="DataContractTests\DataContractSampleClassess.cs" />
     <Compile Include="DataContractTests\PrivateFieldsSerializeTests.cs" />
     <Compile Include="DataContractTests\PrivateGetterSettersSerializeTests.cs" />

--- a/src/SimpleJson/EscapeToJavascriptStringTests.cs
+++ b/src/SimpleJson/EscapeToJavascriptStringTests.cs
@@ -1,0 +1,62 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="<file>.cs" company="The Outercurve Foundation">
+//    Copyright (c) 2011, The Outercurve Foundation.
+//
+//    Licensed under the MIT License (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//      http://www.opensource.org/licenses/mit-license.php
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// </copyright>
+// <author>Nathan Totten (ntotten.com), Jim Zimmerman (jimzimmerman.com) and Prabir Shrestha (prabir.me)</author>
+// <website>https://github.com/facebook-csharp-sdk/simple-json</website>
+//-----------------------------------------------------------------------
+
+namespace SimpleJsonTests
+{
+
+#if NUNIT
+    using TestClass = NUnit.Framework.TestFixtureAttribute;
+    using TestMethod = NUnit.Framework.TestAttribute;
+    using TestCleanup = NUnit.Framework.TearDownAttribute;
+    using TestInitialize = NUnit.Framework.SetUpAttribute;
+    using ClassCleanup = NUnit.Framework.TestFixtureTearDownAttribute;
+    using ClassInitialize = NUnit.Framework.TestFixtureSetUpAttribute;
+    using NUnit.Framework;
+#else
+#if NETFX_CORE
+    using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+#else
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+#endif
+#endif
+
+    using SimpleJson;
+
+    [TestClass]
+    public class EscapeToJavascriptStringTests
+    {
+        [TestMethod]
+        public void BackSlash()
+        {
+            var serialized = SimpleJson.SerializeObject("c:\\haha.pl");
+            var result = SimpleJson.EscapeToJavascriptString(serialized);
+
+            Assert.AreEqual("\"c:\\haha.pl\"", result);
+        }
+
+        [TestMethod]
+        public void BackSlashWithT()
+        {
+            var serialized = SimpleJson.SerializeObject("c:\\taha.pl");
+            var result = SimpleJson.EscapeToJavascriptString(serialized);
+
+            Assert.AreEqual("\"c:\\taha.pl\"", result);
+        }
+    }
+}

--- a/src/SimpleJson/SimpleJson-Net20.csproj
+++ b/src/SimpleJson/SimpleJson-Net20.csproj
@@ -38,6 +38,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="EscapeToJavascriptStringTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SimpleJson.cs" />
   </ItemGroup>


### PR DESCRIPTION
This test actually comes from a scenario in RestSharp.

Given a root JSON array that matches a generic list, we should be able to deserialize that to a type that derives from that generic list.

I added some unit tests that illustrate the issue.
