### PR TITLE
Add support for .NET 4.5 readonly collections

### DIFF
--- a/src/SimpleJson/SimpleJson-Net45.csproj
+++ b/src/SimpleJson/SimpleJson-Net45.csproj
@@ -17,7 +17,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Net45\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;SIMPLE_JSON_DATACONTRACT;SIMPLE_JSON_DYNAMIC;</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SIMPLE_JSON_DATACONTRACT;SIMPLE_JSON_DYNAMIC;SIMPLE_JSON_READONLY_COLLECTIONS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -25,7 +25,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Net45\Release\</OutputPath>
-    <DefineConstants>TRACE;SIMPLE_JSON_DATACONTRACT;SIMPLE_JSON_DYNAMIC;</DefineConstants>
+    <DefineConstants>TRACE;SIMPLE_JSON_DATACONTRACT;SIMPLE_JSON_DYNAMIC;SIMPLE_JSON_READONLY_COLLECTIONS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/src/SimpleJson/SimpleJson-Portable-WP8WinStoreNet45.csproj
+++ b/src/SimpleJson/SimpleJson-Portable-WP8WinStoreNet45.csproj
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\PCLiWP8WinStoreNet45\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;SIMPLE_JSON_TYPEINFO;SIMPLE_JSON_DATACONTRACT;</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;SIMPLE_JSON_TYPEINFO;SIMPLE_JSON_DATACONTRACT;SIMPLE_JSON_READONLY_COLLECTIONS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -28,7 +28,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\PCLiWP8WinStoreNet45\Release\</OutputPath>
-    <DefineConstants>TRACE;SIMPLE_JSON_TYPEINFO;SIMPLE_JSON_DATACONTRACT;</DefineConstants>
+    <DefineConstants>TRACE;SIMPLE_JSON_TYPEINFO;SIMPLE_JSON_DATACONTRACT;SIMPLE_JSON_READONLY_COLLECTIONS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/src/SimpleJson/SimpleJson.cs
+++ b/src/SimpleJson/SimpleJson.cs
@@ -1646,7 +1646,14 @@ namespace SimpleJson
 
                 Type genericDefinition = type.GetGenericTypeDefinition();
 
-                return (genericDefinition == typeof(IList<>) || genericDefinition == typeof(ICollection<>) || genericDefinition == typeof(IEnumerable<>));
+                return (genericDefinition == typeof(IList<>)
+                    || genericDefinition == typeof(ICollection<>)
+                    || genericDefinition == typeof(IEnumerable<>)
+#if SIMPLE_JSON_READONLY_COLLECTIONS
+                    || genericDefinition == typeof(IReadOnlyCollection<>)
+                    || genericDefinition == typeof(IReadOnlyList<>)
+#endif
+                    );
             }
 
             public static bool IsAssignableFrom(Type type1, Type type2)


### PR DESCRIPTION
This also adds a new compiler constant: `SIMPLE_JSON_READONLY_COLLECTIONS` for
platforms that support `IReadOnlyList<>` and `IReadOnlyCollection<>`

/cc @shiftkey
