### PR TITLE
Micro-optimize string serialization

### DIFF
--- a/src/SimpleJson/SimpleJson.cs
+++ b/src/SimpleJson/SimpleJson.cs
@@ -519,7 +519,7 @@ namespace SimpleJson
 
         static SimpleJson()
         {
-            escapeTable = new char[128];
+            escapeTable = new char[93];
             escapeTable['"']  = '"';
             escapeTable['\\'] = '\\';
             escapeTable['\b'] = 'b';
@@ -1114,7 +1114,7 @@ namespace SimpleJson
                 // Non ascii characters are fine, buffer them up and send them to the builder
                 // in larger chunks if possible. The escape table is a 1:1 translation table
                 // with \0 [default(char)] denoting a safe character.
-                if (c >= 128 || escapeTable[c] == default(char))
+                if (c >= escapeTable.Length || escapeTable[c] == default(char))
                 {
                     safeCharacterCount++;
                 }

--- a/src/SimpleJson/SimpleJson.cs
+++ b/src/SimpleJson/SimpleJson.cs
@@ -1074,8 +1074,20 @@ namespace SimpleJson
             return true;
         }
 
+        static readonly char[] escapeCharacters = new char[] { '"', '\\', '\b', '\f', '\n', '\r', '\t' };
+
         static bool SerializeString(string aString, StringBuilder builder)
         {
+            // Happy path if there's nothing to be escaped. IndexOfAny is highly optimized (and unmanaged)
+            if (aString.IndexOfAny(escapeCharacters) == -1)
+            {
+                builder.Append('"');
+                builder.Append(aString);
+                builder.Append('"');
+
+                return true;
+            }
+
             builder.Append("\"");
             char[] charArray = aString.ToCharArray();
             for (int i = 0; i < charArray.Length; i++)

--- a/src/SimpleJson/SimpleJson.cs
+++ b/src/SimpleJson/SimpleJson.cs
@@ -515,20 +515,20 @@ namespace SimpleJson
         private const int TOKEN_NULL = 11;
         private const int BUILDER_CAPACITY = 2000;
 
-        private static readonly char[] escapeTable;
-        private static readonly char[] escapeCharacters = new char[] { '"', '\\', '\b', '\f', '\n', '\r', '\t' };
-        private static readonly string escapeCharactersString = new string(escapeCharacters);
+        private static readonly char[] EscapeTable;
+        private static readonly char[] EscapeCharacters = new char[] { '"', '\\', '\b', '\f', '\n', '\r', '\t' };
+        private static readonly string EscapeCharactersString = new string(EscapeCharacters);
 
         static SimpleJson()
         {
-            escapeTable = new char[93];
-            escapeTable['"']  = '"';
-            escapeTable['\\'] = '\\';
-            escapeTable['\b'] = 'b';
-            escapeTable['\f'] = 'f';
-            escapeTable['\n'] = 'n';
-            escapeTable['\r'] = 'r';
-            escapeTable['\t'] = 't';
+            EscapeTable = new char[93];
+            EscapeTable['"']  = '"';
+            EscapeTable['\\'] = '\\';
+            EscapeTable['\b'] = 'b';
+            EscapeTable['\f'] = 'f';
+            EscapeTable['\n'] = 'n';
+            EscapeTable['\r'] = 'r';
+            EscapeTable['\t'] = 't';
         }
 
         /// <summary>
@@ -1093,7 +1093,7 @@ namespace SimpleJson
         static bool SerializeString(string aString, StringBuilder builder)
         {
             // Happy path if there's nothing to be escaped. IndexOfAny is highly optimized (and unmanaged)
-            if (aString.IndexOfAny(escapeCharacters) == -1)
+            if (aString.IndexOfAny(EscapeCharacters) == -1)
             {
                 builder.Append('"');
                 builder.Append(aString);
@@ -1113,7 +1113,7 @@ namespace SimpleJson
                 // Non ascii characters are fine, buffer them up and send them to the builder
                 // in larger chunks if possible. The escape table is a 1:1 translation table
                 // with \0 [default(char)] denoting a safe character.
-                if (c >= escapeTable.Length || escapeTable[c] == default(char))
+                if (c >= EscapeTable.Length || EscapeTable[c] == default(char))
                 {
                     safeCharacterCount++;
                 }
@@ -1126,7 +1126,7 @@ namespace SimpleJson
                     }
 
                     builder.Append('\\');
-                    builder.Append(escapeTable[c]);
+                    builder.Append(EscapeTable[c]);
                 }
             }
 

--- a/src/SimpleJson/SimpleJson.cs
+++ b/src/SimpleJson/SimpleJson.cs
@@ -1117,17 +1117,18 @@ namespace SimpleJson
                 if (c >= 128 || escapeTable[c] == default(char))
                 {
                     safeCharacterCount++;
-                    continue;
                 }
-
-                if (safeCharacterCount > 0)
+                else
                 {
-                    builder.Append(charArray, i - safeCharacterCount, safeCharacterCount);
-                    safeCharacterCount = 0;
-                }
+                    if (safeCharacterCount > 0)
+                    {
+                        builder.Append(charArray, i - safeCharacterCount, safeCharacterCount);
+                        safeCharacterCount = 0;
+                    }
 
-                builder.Append('\\');
-                builder.Append(escapeTable[c]);
+                    builder.Append('\\');
+                    builder.Append(escapeTable[c]);
+                }
             }
 
             if (safeCharacterCount > 0)

--- a/src/SimpleJson/SimpleJson.cs
+++ b/src/SimpleJson/SimpleJson.cs
@@ -515,7 +515,7 @@ namespace SimpleJson
         private const int TOKEN_NULL = 11;
         private const int BUILDER_CAPACITY = 2000;
 
-        readonly static char[] escapeTable;
+        private static readonly char[] escapeTable;
 
         static SimpleJson()
         {
@@ -1088,8 +1088,8 @@ namespace SimpleJson
             return true;
         }
 
-        static readonly char[] escapeCharacters = new char[] { '"', '\\', '\b', '\f', '\n', '\r', '\t' };
-        static readonly string escapeCharactersString = new string(escapeCharacters);
+        private static readonly char[] escapeCharacters = new char[] { '"', '\\', '\b', '\f', '\n', '\r', '\t' };
+        private static readonly string escapeCharactersString = new string(escapeCharacters);
 
         static bool SerializeString(string aString, StringBuilder builder)
         {

--- a/src/SimpleJson/SimpleJson.cs
+++ b/src/SimpleJson/SimpleJson.cs
@@ -516,6 +516,8 @@ namespace SimpleJson
         private const int BUILDER_CAPACITY = 2000;
 
         private static readonly char[] escapeTable;
+        private static readonly char[] escapeCharacters = new char[] { '"', '\\', '\b', '\f', '\n', '\r', '\t' };
+        private static readonly string escapeCharactersString = new string(escapeCharacters);
 
         static SimpleJson()
         {
@@ -1087,9 +1089,6 @@ namespace SimpleJson
             builder.Append("]");
             return true;
         }
-
-        private static readonly char[] escapeCharacters = new char[] { '"', '\\', '\b', '\f', '\n', '\r', '\t' };
-        private static readonly string escapeCharactersString = new string(escapeCharacters);
 
         static bool SerializeString(string aString, StringBuilder builder)
         {

--- a/src/SimpleJson/SimpleJson.cs
+++ b/src/SimpleJson/SimpleJson.cs
@@ -1106,7 +1106,6 @@ namespace SimpleJson
             builder.Append('"');
             int safeCharacterCount = 0;
             char[] charArray = aString.ToCharArray();
-            char[] escapeBuf = new char[2] { '\\', '\0' };
 
             for (int i = 0; i < charArray.Length; i++)
             {
@@ -1127,8 +1126,8 @@ namespace SimpleJson
                     safeCharacterCount = 0;
                 }
 
-                escapeBuf[1] = escapeTable[c];
-                builder.Append(escapeBuf, 0, 2);
+                builder.Append('\\');
+                builder.Append(escapeTable[c]);
             }
 
             if (safeCharacterCount > 0)


### PR DESCRIPTION
While profiling an extremely high-write scenario in one of my apps I found that a decent amount of time was being spent serializing (read: escaping) strings. My objects consisted almost exclusively of strings so I went in to see if there was any perf gains to be made.

I started out by optimizing the happy path of the string not needing to be escaped at all (ie no unsafe characters) and that change (cece3e4) is probably pretty uncontroversial. Then I went to town on the loop, still optimizing for there being fewer unsafe characters than safe, buffering up stringbuilder writes to ranges of safe characters. This lead to a small perf hit for extremely short string and a pretty decent speed increase for slightly largers strings.
## Benchmark

This compares two scenarios, one where the string doesn't contain any unsafe characters (which I would guess is the case for most strings going through SimpleJson) and one where the string contains a percentage of unsafe characters. Each runs 1000000 iterations of serialize and runs GC collect in between each test to make sure garbage left over from the last run doesn't affect the outcome of the second.

![string-perf](https://f.cloud.github.com/assets/634063/2241362/7ef19c08-9ccd-11e3-821e-460c8ceecf87.png)

The test string with unsafe characters have a uniform distribution of unsafe characters which perhaps isn't that probable in a real-world scenario but it _shouldn't_ significantly influence the outcome of the benchmark.

Worth noting is that while the percentages here are quite nice the wall time decrease isn't massively impressive. Long story short the stuff that's in there now is quick enough for the vast majority of scenarios. I just wanted to say that so you can consider whether or not its worth accepting or not. If you decide it's not worth it please do still consider cece3e4 as a separate change because that's a happy path which will have real impact on serialization.
