### PR TITLE
Win8 get properties

### DIFF
--- a/src/SimpleJson.Tests/PocoJsonSerializerTests/InheritanceSerializeTests.cs
+++ b/src/SimpleJson.Tests/PocoJsonSerializerTests/InheritanceSerializeTests.cs
@@ -1,0 +1,67 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="InheritanceSerializeTests.cs" company="The Outercurve Foundation">
+//    Copyright (c) 2011, The Outercurve Foundation.
+//
+//    Licensed under the MIT License (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//      http://www.opensource.org/licenses/mit-license.php
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// </copyright>
+// <author>Nathan Totten (ntotten.com), Jim Zimmerman (jimzimmerman.com) and Prabir Shrestha (prabir.me)</author>
+// <website>https://github.com/facebook-csharp-sdk/simple-json</website>
+//-----------------------------------------------------------------------
+
+namespace SimpleJson.Tests.PocoJsonSerializerTests
+{
+    using System;
+
+#if NUNIT
+    using TestClass = NUnit.Framework.TestFixtureAttribute;
+    using TestMethod = NUnit.Framework.TestAttribute;
+    using TestCleanup = NUnit.Framework.TearDownAttribute;
+    using TestInitialize = NUnit.Framework.SetUpAttribute;
+    using ClassCleanup = NUnit.Framework.TestFixtureTearDownAttribute;
+    using ClassInitialize = NUnit.Framework.TestFixtureSetUpAttribute;
+    using NUnit.Framework;
+#else
+#if NETFX_CORE
+    using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+#else
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+#endif
+#endif
+
+    [TestClass]
+    public class InheritanceSerializeTests
+    {
+        [TestMethod]
+        public void SerializeShouldContainInheritedProperties()
+        {
+            var dog = new Dog
+            {
+                Type = "dog",
+                Legs = 4
+            };
+
+            var actual = SimpleJson.SerializeObject(dog);
+            var expected = "{\"Legs\":4,\"Type\":\"dog\"}";
+            Assert.AreEqual(expected, actual);
+        }
+
+        public class Animal
+        {
+            public string Type { get; set; }
+        }
+
+        public class Dog : Animal
+        {
+            public int Legs { get; set; }
+        }
+    }
+}

--- a/src/SimpleJson.Tests/SimleJson.Tests-WindowsStore.csproj
+++ b/src/SimpleJson.Tests/SimleJson.Tests-WindowsStore.csproj
@@ -138,6 +138,7 @@
     <Compile Include="PocoDeserializerTests\ListOfPocoDeserializeTests.cs" />
     <Compile Include="PocoDeserializerTests\NullableTypeDeserializeTests.cs" />
     <Compile Include="PocoJsonSerializerTests\DateTimeSerializeTests.cs" />
+    <Compile Include="PocoJsonSerializerTests\InheritanceSerializeTests.cs" />
     <Compile Include="PocoJsonSerializerTests\NullableSerializeTests.cs" />
     <Compile Include="PocoJsonSerializerTests\PrivateFieldsDeserializeTests.cs" />
     <Compile Include="PocoJsonSerializerTests\PrivateFieldsSerializeTests.cs" />

--- a/src/SimpleJson.Tests/SimpleJson.Tests.csproj
+++ b/src/SimpleJson.Tests/SimpleJson.Tests.csproj
@@ -76,6 +76,7 @@
     <Compile Include="PocoDeserializerTests\DictionaryDeserializeTests.cs" />
     <Compile Include="PocoDeserializerTests\ListOfPocoDeserializeTests.cs" />
     <Compile Include="PocoJsonSerializerTests\DateTimeSerializeTests.cs" />
+    <Compile Include="PocoJsonSerializerTests\InheritanceSerializeTests.cs" />
     <Compile Include="PocoJsonSerializerTests\NullableSerializeTests.cs" />
     <Compile Include="PocoJsonSerializerTests\PrivateFieldsDeserializeTests.cs" />
     <Compile Include="PocoJsonSerializerTests\PrivateFieldsSerializeTests.cs" />

--- a/src/SimpleJson/SimpleJson.cs
+++ b/src/SimpleJson/SimpleJson.cs
@@ -1773,7 +1773,7 @@ namespace SimpleJson
             public static IEnumerable<PropertyInfo> GetProperties(Type type)
             {
 #if SIMPLE_JSON_TYPEINFO
-                return type.GetTypeInfo().DeclaredProperties;
+                return type.GetRuntimeProperties();
 #else
                 return type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
 #endif


### PR DESCRIPTION
:warning: don't merge yet :warning: 

PR for #46 
- added failing test
- added fix for `ReflectionUtils.GetProperties` so it includes properties from base class.
- ignoring path for `ReflectionUtils.GetFields`

Before this can be merged:
- separate PR must be sent to reflection-utils
- make sure all facebook-c#-sdk tests passes
- make sure all octokit.net tests passes
- need to test with lower version of .NET Framework in PCL

`GetRuntimeProperties` is documented in msdn at http://msdn.microsoft.com/en-us/library/system.reflection.runtimereflectionextensions.getruntimeproperties(v=vs.110).aspx

.NET Framework
Supported in: 4.5.1, 4.5

.NET for Windows Store apps
Supported in: Windows 8
