### PR TITLE
Support for TimeSpan

### DIFF
--- a/src/SimpleJson.Tests/SerializeObject.KnownNonPrimitive.Tests.cs
+++ b/src/SimpleJson.Tests/SerializeObject.KnownNonPrimitive.Tests.cs
@@ -51,6 +51,49 @@ namespace SimpleJsonTests
         }
 
         [TestMethod]
+        public void TimeSpanSerialization()
+        {
+            TimeSpan timeSpan = TimeSpan.FromSeconds(3661);
+
+            var json = SimpleJson.SerializeObject(timeSpan);
+
+            Assert.AreEqual(@"""01:01:01""", json);
+        }
+
+        [TestMethod]
+        public void TimeSpanDaysSerialization()
+        {
+            TimeSpan timeSpan = TimeSpan.FromDays(2);
+
+            var json = SimpleJson.SerializeObject(timeSpan);
+
+            Assert.AreEqual(@"""2.00:00:00""", json);
+        }
+
+        [TestMethod]
+        public void TimeSpanDeSerialization()
+        {
+            TimeSpan timeSpan = TimeSpan.FromDays(2);
+
+            var json = SimpleJson.SerializeObject(timeSpan);
+
+            TimeSpan timeSpanOut = (TimeSpan)SimpleJson.DeserializeObject(json, typeof(TimeSpan));
+
+            Assert.AreEqual(timeSpan, timeSpanOut);
+        }
+
+
+        [TestMethod]
+        public void TimeSpanZeroSerialization()
+        {
+            TimeSpan timeSpan = TimeSpan.Zero;
+
+            var json = SimpleJson.SerializeObject(timeSpan);
+
+            Assert.AreEqual(@"""00:00:00""", json);
+        }
+
+        [TestMethod]
         public void EnumSerialization()
         {
             string json = SimpleJson.SerializeObject(StringComparison.CurrentCultureIgnoreCase);

--- a/src/SimpleJson/SimpleJson.cs
+++ b/src/SimpleJson/SimpleJson.cs
@@ -1348,7 +1348,9 @@ namespace SimpleJson
                         return DateTimeOffset.ParseExact(str, Iso8601Format, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
                     if (type == typeof(Guid) || (ReflectionUtils.IsNullableType(type) && Nullable.GetUnderlyingType(type) == typeof(Guid)))
                         return new Guid(str);
-                    if (type == typeof(Uri))
+                    if (type == typeof(TimeSpan) || (ReflectionUtils.IsNullableType(type) && Nullable.GetUnderlyingType(type) == typeof(TimeSpan)))
+                        return TimeSpan.Parse(str);
+                      if (type == typeof(Uri))
                     {
                         bool isValid =  Uri.IsWellFormedUriString(str, UriKind.RelativeOrAbsolute);
 
@@ -1477,6 +1479,8 @@ namespace SimpleJson
                 output = ((DateTime)input).ToUniversalTime().ToString(Iso8601Format[0], CultureInfo.InvariantCulture);
             else if (input is DateTimeOffset)
                 output = ((DateTimeOffset)input).ToUniversalTime().ToString(Iso8601Format[0], CultureInfo.InvariantCulture);
+            else if (input is TimeSpan)
+                output = ((TimeSpan)input).ToString();
             else if (input is Guid)
                 output = ((Guid)input).ToString("D");
             else if (input is Uri)

--- a/src/SimpleJson/SimpleJson.cs
+++ b/src/SimpleJson/SimpleJson.cs
@@ -1350,7 +1350,7 @@ namespace SimpleJson
                         return new Guid(str);
                     if (type == typeof(TimeSpan) || (ReflectionUtils.IsNullableType(type) && Nullable.GetUnderlyingType(type) == typeof(TimeSpan)))
                         return TimeSpan.Parse(str);
-                      if (type == typeof(Uri))
+                    if (type == typeof(Uri))
                     {
                         bool isValid =  Uri.IsWellFormedUriString(str, UriKind.RelativeOrAbsolute);
 


### PR DESCRIPTION
Currently when a TimeSpan is being Serialized it's being treated as an unknown type and ends up in TrySerializeUnknownTypes where it's reflected on and serialized as

``` json
{
    "Ticks":10040000000,
    "Days":0,
    "Hours":0,
    "Milliseconds":0,
    "Minutes":16,
    "Seconds":44,
    "TotalDays":0.011620370370370369,
    "TotalHours":0.27888888888888885,
    "TotalMilliseconds":1004000,
    "TotalMinutes":16.733333333333334,
    "TotalSeconds":1004
  }
```

 I added explicit checks for TimeSpan. Not 100% sure what the TimeSpan Format strings should be so I stuck with the defaults.
