### PR TITLE
Optionally support DataContract in Mono/Unity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# Fork Purpose
+Support for ```DataContract``` in Unity3d/Mono, as mono does not implement all WCF classes, this fork implements them in ```SimpleJson``` namespace if ```ALTERNATE_DATACONTRACT``` was defined.
+
 # SimpleJson
 Small and fast JSON library for .NET 2.0+/SL4+/WP7+/Windows Store Apps/Portable Class Library and powershell.
 Includes support for dynamic in .NET 4.0+/SL4+/Windows Store Apps. Also includes support for DataContract and DataMember. 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-# Fork Purpose
-Support for ```DataContract``` in Unity3d/Mono, as mono does not implement all WCF classes, this fork implements them in ```SimpleJson``` namespace if ```ALTERNATE_DATACONTRACT``` was defined.
-
 # SimpleJson
 Small and fast JSON library for .NET 2.0+/SL4+/WP7+/Windows Store Apps/Portable Class Library and powershell.
 Includes support for dynamic in .NET 4.0+/SL4+/Windows Store Apps. Also includes support for DataContract and DataMember. 

--- a/src/SimpleJson/SimpleJson.cs
+++ b/src/SimpleJson/SimpleJson.cs
@@ -32,7 +32,7 @@
 //#define SIMPLE_JSON_DATACONTRACT
 
 // NOTE: uncomment the following line to use alternate definitions of DataContract/DataMember/IgnoreDataMember.
-// define if you want to use DataContract with Mono, which does not implement all WCF classes.
+// define if you want to use DataContract with Unity/Mono, which does not implement all WCF classes.
 //#define SIMPLE_JSON_REDEFINE_DATACONTRACT_ATTRIBUTES
 
 // NOTE: uncomment the following line to enable IReadOnlyCollection<T> and IReadOnlyList<T> support.

--- a/src/SimpleJson/SimpleJson.cs
+++ b/src/SimpleJson/SimpleJson.cs
@@ -494,19 +494,47 @@ namespace SimpleJson
 
 #if SIMPLE_JSON_REDEFINE_DATACONTRACT_ATTRIBUTES
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum, Inherited = false, AllowMultiple = false)]
-    public sealed class DataContractAttribute : Attribute
+#if SIMPLE_JSON_INTERNAL
+    internal
+#else
+    public
+#endif
+ sealed class DataContractAttribute : Attribute
     {
         public string Name { get; set; }
     }
 
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, Inherited = false, AllowMultiple = false)]
-    public sealed class DataMemberAttribute : Attribute
+#if SIMPLE_JSON_INTERNAL
+    internal
+#else
+    public
+#endif
+ sealed class DataMemberAttribute : Attribute
     {
+        public DataMemberAttribute()
+        {
+        }
+
+        /// <summary>
+        /// this constructor simplifies declaring this attribute by writing [DataMember("name")] instead of [DataMember(Name = "name")]
+        /// </summary>
+        /// <param name="name"></param>
+        public DataMemberAttribute(string name)
+        {
+            Name = name;
+        }
+
         public string Name { get; set; }
     }
 
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, Inherited = false, AllowMultiple = false)]
-    public sealed class IgnoreDataMemberAttribute : Attribute
+#if SIMPLE_JSON_INTERNAL
+    internal
+#else
+    public
+#endif
+ sealed class IgnoreDataMemberAttribute : Attribute
     {
     }
 #endif

--- a/src/SimpleJson/SimpleJson.cs
+++ b/src/SimpleJson/SimpleJson.cs
@@ -33,7 +33,7 @@
 
 // NOTE: uncomment the following line to use alternate definitions of DataContract/DataMember/IgnoreDataMember.
 // define if you want to use DataContract with Mono, which does not implement all WCF classes.
-//#define ALTERNATE_DATACONTRACT
+//#define SIMPLE_JSON_REDEFINE_DATACONTRACT_ATTRIBUTES
 
 // NOTE: uncomment the following line to enable IReadOnlyCollection<T> and IReadOnlyList<T> support.
 //#define SIMPLE_JSON_READONLY_COLLECTIONS
@@ -492,7 +492,7 @@ namespace SimpleJson
 {
     #region Alternate DataContract for Unity/Mono
 
-#if ALTERNATE_DATACONTRACT
+#if SIMPLE_JSON_REDEFINE_DATACONTRACT_ATTRIBUTES
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum, Inherited = false, AllowMultiple = false)]
     public sealed class DataContractAttribute : Attribute
     {

--- a/src/SimpleJson/SimpleJson.cs
+++ b/src/SimpleJson/SimpleJson.cs
@@ -31,6 +31,10 @@
 // NOTE: uncomment the following line to enable DataContract support.
 //#define SIMPLE_JSON_DATACONTRACT
 
+// NOTE: uncomment the following line to use alternate definitions of DataContract/DataMember/IgnoreDataMember.
+// define if you want to use DataContract with Mono, which does not implement all WCF classes.
+//#define ALTERNATE_DATACONTRACT
+
 // NOTE: uncomment the following line to enable IReadOnlyCollection<T> and IReadOnlyList<T> support.
 //#define SIMPLE_JSON_READONLY_COLLECTIONS
 
@@ -486,6 +490,29 @@ namespace SimpleJson
 
 namespace SimpleJson
 {
+    #region Alternate DataContract for Unity/Mono
+
+#if ALTERNATE_DATACONTRACT
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum, Inherited = false, AllowMultiple = false)]
+    public sealed class DataContractAttribute : Attribute
+    {
+        public string Name { get; set; }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, Inherited = false, AllowMultiple = false)]
+    public sealed class DataMemberAttribute : Attribute
+    {
+        public string Name { get; set; }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, Inherited = false, AllowMultiple = false)]
+    public sealed class IgnoreDataMemberAttribute : Attribute
+    {
+    }
+#endif
+
+    #endregion
+
     /// <summary>
     /// This class encodes and decodes JSON strings.
     /// Spec. details, see http://www.json.org/


### PR DESCRIPTION
Mono doesn't implement the attributes DataContract/DataMember/IgnoreDataMember, so to be able to use them in Unity/Mono i added a define to implement them in SimpleJson namespace, just define ALTERNATE_DATACONTRACT to enable the alternate definition.
