### PR TITLE
Bug deserializing to list when single object returned

### DIFF
--- a/src/SimpleJson.Tests/DeserializeGenericListTests.cs
+++ b/src/SimpleJson.Tests/DeserializeGenericListTests.cs
@@ -96,5 +96,16 @@ namespace SimpleJsonTests
             Assert.AreEqual("bar0", result[0].SomeProperty);
             Assert.AreEqual("bar1", result[1].SomeProperty);
         }
+
+        [TestMethod]
+        public void Can_Deserialize_Root_Json_Array_To_Inherited_List_With_Single_Object()
+        {
+            var json = @"{""SomeProperty"":""bar0""}";
+            var result = SimpleJson.DeserializeObject<ItemList>(json);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual("bar0", result[0].SomeProperty);
+        }
     }
 }

--- a/src/SimpleJson/SimpleJson.cs
+++ b/src/SimpleJson/SimpleJson.cs
@@ -1413,6 +1413,16 @@ namespace SimpleJson
 
                         obj = dict;
                     }
+                    if (ReflectionUtils.IsTypeGenericeCollectionInterface(type) || ReflectionUtils.IsAssignableFrom(typeof(IList), type))
+                    {
+                        IList list = null;
+
+                        Type innerType = ReflectionUtils.GetGenericListElementType(type);
+                        list = (IList)(ConstructorCache[type] ?? ConstructorCache[typeof(List<>).MakeGenericType(innerType)])(jsonObject.Count);
+                        list.Add(DeserializeObject(objects, innerType));
+
+                        obj = list;
+                    }
                     else
                     {
                         if (type == typeof(object))


### PR DESCRIPTION
There is a bug I found using Generic Lists when the object to be deserialized is not part of a collection and is rather an object.
This includes two commits.  The first commit is the failing unit test.  The second commit is the code to fix the bug.
