### PR TITLE
Add support for deserializing readonly dictionaries

### DIFF
--- a/src/SimpleJson.Tests/PocoDeserializerTests/DictionaryDeserializeTests.cs
+++ b/src/SimpleJson.Tests/PocoDeserializerTests/DictionaryDeserializeTests.cs
@@ -17,9 +17,13 @@
 // <website>https://github.com/facebook-csharp-sdk/simple-json</website>
 //-----------------------------------------------------------------------
 
+
 namespace SimpleJsonTests.PocoDeserializerTests
 {
     using System.Collections.Generic;
+#if SIMPLE_JSON_READONLY_COLLECTIONS
+    using System.Collections.ObjectModel;
+#endif
 
 #if NUNIT
     using TestMethod = NUnit.Framework.TestAttribute;
@@ -74,6 +78,35 @@ namespace SimpleJsonTests.PocoDeserializerTests
             Assert.AreEqual(1L, result["key1"]);
             Assert.AreEqual(5L, result["key2"]);
         }
+
+#if SIMPLE_JSON_READONLY_COLLECTIONS
+        // Running these next two tests requires recompiling the tests against the SimpleJson-Net45 project
+        [TestMethod]
+        public void DeserializeToIReadOnlyDictionaryStringLong()
+        {
+            string json = @"{""key1"":1,""key2"":5}";   
+
+            var result = SimpleJson.DeserializeObject<IReadOnlyDictionary<string, long>>(json);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(1L, result["key1"]);
+            Assert.AreEqual(5L, result["key2"]);
+        }
+
+        [TestMethod]
+        public void DeserializeToReadOnlyDictionaryStringLong()
+        {
+            string json = @"{""key1"":1,""key2"":5}";
+
+            var result = SimpleJson.DeserializeObject<ReadOnlyDictionary<string, long>>(json);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(1L, result["key1"]);
+            Assert.AreEqual(5L, result["key2"]);
+        }
+#endif
 
         [TestMethod]
         public void DeserializeToDictionaryStringLong()

--- a/src/SimpleJson/SimpleJson.cs
+++ b/src/SimpleJson/SimpleJson.cs
@@ -1424,7 +1424,7 @@ namespace SimpleJson
                         {
                             var ctorType = typeof(IDictionary<,>).MakeGenericType(keyType, valueType);
                             var genericReadonlyType = typeof(ReadOnlyDictionary<,>).MakeGenericType(keyType, valueType);
-                            var ctor = genericReadonlyType.GetConstructor(new Type[] { ctorType });
+                            var ctor = ReflectionUtils.GetContructor(genericReadonlyType, new Type[] { ctorType });
                             System.Diagnostics.Debug.Assert(ctor != null);
                             obj = ctor.Invoke(new[] { obj });
                         }

--- a/src/SimpleJson/SimpleJson.cs
+++ b/src/SimpleJson/SimpleJson.cs
@@ -54,6 +54,9 @@ using System;
 using System.CodeDom.Compiler;
 using System.Collections;
 using System.Collections.Generic;
+#if SIMPLE_JSON_READONLY_COLLECTIONS
+using System.Collections.ObjectModel;
+#endif
 #if !SIMPLE_JSON_NO_LINQ_EXPRESSION
 using System.Linq.Expressions;
 #endif
@@ -1412,6 +1415,21 @@ namespace SimpleJson
                             dict.Add(kvp.Key, DeserializeObject(kvp.Value, valueType));
 
                         obj = dict;
+
+#if SIMPLE_JSON_READONLY_COLLECTIONS
+                        // Wrap dictionary in a ReadOnlyDictionary<,>
+                        var genericTypeDefinition = type.GetGenericTypeDefinition();
+                        if (genericTypeDefinition == typeof(IReadOnlyDictionary<,>) ||
+                            genericTypeDefinition == typeof(ReadOnlyDictionary<,>))
+                        {
+                            var ctorType = typeof(IDictionary<,>).MakeGenericType(keyType, valueType);
+                            var genericReadonlyType = typeof(ReadOnlyDictionary<,>).MakeGenericType(keyType, valueType);
+                            var ctor = genericReadonlyType.GetConstructor(new Type[] { ctorType });
+                            System.Diagnostics.Debug.Assert(ctor != null);
+                            obj = ctor.Invoke(new[] { obj });
+                        }
+#endif
+
                     }
                     else
                     {
@@ -1720,7 +1738,11 @@ namespace SimpleJson
                     return false;
 
                 Type genericDefinition = type.GetGenericTypeDefinition();
-                return genericDefinition == typeof(IDictionary<,>);
+                return genericDefinition == typeof(IDictionary<,>)
+#if SIMPLE_JSON_READONLY_COLLECTIONS
+                    || genericDefinition == typeof(IReadOnlyDictionary<,>)
+#endif
+                    ;
             }
 
             public static bool IsNullableType(Type type)


### PR DESCRIPTION
This adds support for deserializing `IReadOnlyDictionary<,>` and `ReadOnlyDictionary<,>`. We forgot these when we implemented support for
the `#SIMPLE_JSON_READONLY_COLLECTIONS` conditional.
